### PR TITLE
Add API base URL support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.1
+current_version = 0.13.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>.*))?

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 setuptools.setup(
     name="OctoPrint-PSUControl-Meross",
-    version="0.13.1",
+    version="0.13.2",
     description="Adds Meross Smart Plug support to OctoPrint-PSUControl",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/octoprint_psucontrol_meross/meross_client.py
+++ b/src/octoprint_psucontrol_meross/meross_client.py
@@ -105,7 +105,7 @@ class _OctoprintPsuMerossClientAsync:
             await self.api_client.async_logout()
         self.api_client = None
 
-    async def login(self, user: str, password: str, raise_exc: bool):
+    async def login(self, api_base_url: str, user: str, password: str, raise_exc: bool):
         expected_session_key = self._cache.get_session_name_key(user, password)
         self._logger.debug(
             f"login called with user {user!r} "
@@ -126,7 +126,9 @@ class _OctoprintPsuMerossClientAsync:
         self._logger.info(f"Performing full auth login for the user {user!r}.")
         try:
             self.api_client = await MerossHttpClient.async_from_user_password(
-                email=user, password=password
+                api_base_url=api_base_url,
+                email=user,
+                password=password
             )
         except ANY_MEROSS_IOT_EXC:
             self._logger.exception("Error when trying to log in.")
@@ -288,7 +290,7 @@ class OctoprintPsuMerossClient:
             cache_file=cache_file, logger=self._logger.getChild("async_client")
         )
 
-    def login(self, user: str, password: str, raise_exc: bool = False) -> Future:
+    def login(self, api_base_url: str, user: str, password: str, raise_exc: bool = False) -> Future:
         """Login to the meross cloud.
 
         Returns `None` in async mode, or True/False (success state) in sync mode.
@@ -297,7 +299,7 @@ class OctoprintPsuMerossClient:
             self._logger.info("No user/password configured, skipping login")
             return False
         return asyncio.run_coroutine_threadsafe(
-            self._async_client.login(user, password, raise_exc), self.worker.loop
+            self._async_client.login(api_base_url, user, password, raise_exc), self.worker.loop
         )
 
     def list_devices(self):

--- a/src/octoprint_psucontrol_meross/meross_client.py
+++ b/src/octoprint_psucontrol_meross/meross_client.py
@@ -126,9 +126,7 @@ class _OctoprintPsuMerossClientAsync:
         self._logger.info(f"Performing full auth login for the user {user!r}.")
         try:
             self.api_client = await MerossHttpClient.async_from_user_password(
-                api_base_url=api_base_url,
-                email=user,
-                password=password
+                api_base_url=api_base_url, email=user, password=password
             )
         except ANY_MEROSS_IOT_EXC:
             self._logger.exception("Error when trying to log in.")
@@ -238,7 +236,7 @@ class _OctoprintPsuMerossClientAsync:
             ]
         )
         out = []
-        for (device_hanle, (dev_uuid, dev_channel)) in zip(devices, uuid_channel_pairs):
+        for device_hanle, (dev_uuid, dev_channel) in zip(devices, uuid_channel_pairs):
             if not device_hanle:
                 self._logger.error(f"Device {dev_uuid!r} not found.")
                 continue
@@ -249,7 +247,7 @@ class _OctoprintPsuMerossClientAsync:
         assert self.is_authenticated, "Must be authenticated"
         dev_handles = await self.get_device_handles(dev_ids)
         futures = []
-        for (device, channel) in dev_handles:
+        for device, channel in dev_handles:
             if state:
                 the_future = device.async_turn_on(channel=channel)
             else:
@@ -290,7 +288,9 @@ class OctoprintPsuMerossClient:
             cache_file=cache_file, logger=self._logger.getChild("async_client")
         )
 
-    def login(self, api_base_url: str, user: str, password: str, raise_exc: bool = False) -> Future:
+    def login(
+        self, api_base_url: str, user: str, password: str, raise_exc: bool = False
+    ) -> Future:
         """Login to the meross cloud.
 
         Returns `None` in async mode, or True/False (success state) in sync mode.
@@ -299,7 +299,8 @@ class OctoprintPsuMerossClient:
             self._logger.info("No user/password configured, skipping login")
             return False
         return asyncio.run_coroutine_threadsafe(
-            self._async_client.login(api_base_url, user, password, raise_exc), self.worker.loop
+            self._async_client.login(api_base_url, user, password, raise_exc),
+            self.worker.loop,
         )
 
     def list_devices(self):

--- a/src/octoprint_psucontrol_meross/plugin.py
+++ b/src/octoprint_psucontrol_meross/plugin.py
@@ -25,34 +25,27 @@ class PSUControlMeross(
         self._logger.info(f"{self.__class__.__name__} loaded.")
         self._ensure_meross_login()
 
-    def _ensure_meross_login(self, api_base_url=None, user=None, password=None, raise_exc=False):
+    def _ensure_meross_login(
+        self, api_base_url=None, user=None, password=None, raise_exc=False
+    ):
         """Ensures that we are logged in as user/pass
 
         (either provided or values from the settings).
         """
-        if (not api_base_url):
+        if not api_base_url:
             api_base_url = self._settings.get(["api_base_url"])
-        if (not user):
+        if not user:
             user = self._settings.get(["user_email"])
-        if (not password):
+        if not password:
             password = self._settings.get(["user_password"])
         return self.meross.login(api_base_url, user, password, raise_exc=raise_exc)
 
     def get_settings_defaults(self):
         return {
             "api_urls": [
-                {
-                    "name": "Asia-Pacific",
-                    "url": "iotx-ap.meross.com"
-                },
-                {
-                    "name": "Europe",
-                    "url": "iotx-eu.meross.com"
-                },
-                {
-                    "name": "US",
-                    "url": "iotx-us.meross.com"
-                }
+                {"name": "Asia-Pacific", "url": "iotx-ap.meross.com"},
+                {"name": "Europe", "url": "iotx-eu.meross.com"},
+                {"name": "US", "url": "iotx-us.meross.com"},
             ],
             "api_base_url": "iotx-us.meross.com",
             "user_email": "",
@@ -87,7 +80,7 @@ class PSUControlMeross(
         return super().on_settings_save(data)
 
     def on_settings_migrate(self, target, current):
-        for (migrate_from, migrate_to) in zip(
+        for migrate_from, migrate_to in zip(
             range(current, target), range(current + 1, target + 1)
         ):
             if (migrate_from, migrate_to) == (1, 2):
@@ -144,16 +137,23 @@ class PSUControlMeross(
         return {
             "try_login": ("api_base_url", "user_email", "user_password"),
             "list_devices": ("api_base_url", "user_email", "user_password"),
-            "toggle_devices": ("api_base_url", "user_email", "user_password", "dev_ids"),
+            "toggle_devices": (
+                "api_base_url",
+                "user_email",
+                "user_password",
+                "dev_ids",
+            ),
         }
 
     def on_api_command(self, event, payload):
         self._logger.debug(f"ON_EVENT {event!r}")
         if event == "try_login":
-
             try:
                 success = self._ensure_meross_login(
-                    payload["api_base_url"], payload["user_email"], payload["user_password"], raise_exc=True
+                    payload["api_base_url"],
+                    payload["user_email"],
+                    payload["user_password"],
+                    raise_exc=True,
                 ).result()
             except Exception as err:
                 success = False
@@ -170,7 +170,10 @@ class PSUControlMeross(
             err = False
             try:
                 self._ensure_meross_login(
-                    payload["api_base_url"], payload["user_email"], payload["user_password"], raise_exc=True
+                    payload["api_base_url"],
+                    payload["user_email"],
+                    payload["user_password"],
+                    raise_exc=True,
                 ).result()
                 rv = self.meross.toggle_device(payload["dev_id"]).result()
             except Exception as exc:

--- a/src/octoprint_psucontrol_meross/plugin.py
+++ b/src/octoprint_psucontrol_meross/plugin.py
@@ -25,18 +25,36 @@ class PSUControlMeross(
         self._logger.info(f"{self.__class__.__name__} loaded.")
         self._ensure_meross_login()
 
-    def _ensure_meross_login(self, user=None, password=None, raise_exc=False):
+    def _ensure_meross_login(self, api_base_url=None, user=None, password=None, raise_exc=False):
         """Ensures that we are logged in as user/pass
 
         (either provided or values from the settings).
         """
-        if (not user) and (not password):
+        if (not api_base_url):
+            api_base_url = self._settings.get(["api_base_url"])
+        if (not user):
             user = self._settings.get(["user_email"])
+        if (not password):
             password = self._settings.get(["user_password"])
-        return self.meross.login(user, password, raise_exc=raise_exc)
+        return self.meross.login(api_base_url, user, password, raise_exc=raise_exc)
 
     def get_settings_defaults(self):
         return {
+            "api_urls": [
+                {
+                    "name": "Asia-Pacific",
+                    "url": "iotx-ap.meross.com"
+                },
+                {
+                    "name": "Europe",
+                    "url": "iotx-eu.meross.com"
+                },
+                {
+                    "name": "US",
+                    "url": "iotx-us.meross.com"
+                }
+            ],
+            "api_base_url": "iotx-us.meross.com",
             "user_email": "",
             "user_password": "",
             "target_device_ids": [],
@@ -45,6 +63,9 @@ class PSUControlMeross(
     def get_settings_restricted_paths(self):
         return {
             "admin": [
+                [
+                    "api_base_url",
+                ],
                 [
                     "user_email",
                 ],
@@ -121,9 +142,9 @@ class PSUControlMeross(
 
     def get_api_commands(self):
         return {
-            "try_login": ("user_email", "user_password"),
-            "list_devices": ("user_email", "user_password"),
-            "toggle_devices": ("user_email", "user_password", "dev_ids"),
+            "try_login": ("api_base_url", "user_email", "user_password"),
+            "list_devices": ("api_base_url", "user_email", "user_password"),
+            "toggle_devices": ("api_base_url", "user_email", "user_password", "dev_ids"),
         }
 
     def on_api_command(self, event, payload):
@@ -132,7 +153,7 @@ class PSUControlMeross(
 
             try:
                 success = self._ensure_meross_login(
-                    payload["user_email"], payload["user_password"], raise_exc=True
+                    payload["api_base_url"], payload["user_email"], payload["user_password"], raise_exc=True
                 ).result()
             except Exception as err:
                 success = False
@@ -149,7 +170,7 @@ class PSUControlMeross(
             err = False
             try:
                 self._ensure_meross_login(
-                    payload["user_email"], payload["user_password"], raise_exc=True
+                    payload["api_base_url"], payload["user_email"], payload["user_password"], raise_exc=True
                 ).result()
                 rv = self.meross.toggle_device(payload["dev_id"]).result()
             except Exception as exc:

--- a/src/octoprint_psucontrol_meross/static/js/octoprint_psucontrol_settings.js
+++ b/src/octoprint_psucontrol_meross/static/js/octoprint_psucontrol_settings.js
@@ -112,6 +112,7 @@ $(function() {
         }
 
         self.toggle_device = function() {
+            var api_base_url = self.settings.api_base_url();
             var username = self.settings.user_email();
             var password = self.settings.user_password();
             var device_ids = self.settings.target_device_ids();
@@ -126,6 +127,7 @@ $(function() {
                 "psucontrol_meross",
                 "toggle_device",
                 {
+                    "api_base_url": api_base_url,
                     "user_email": username,
                     "user_password": password,
                     "dev_ids": device_ids,
@@ -144,6 +146,7 @@ $(function() {
         }
 
         self.test_meross_cloud_login = function() {
+            var api_base_url = self.settings.api_base_url();
             var username = self.settings.user_email();
             var password = self.settings.user_password();
 
@@ -157,6 +160,7 @@ $(function() {
                 "psucontrol_meross",
                 "try_login",
                 {
+                    "api_base_url": api_base_url,
                     "user_email": username,
                     "user_password": password,
                 }

--- a/src/octoprint_psucontrol_meross/templates/psucontrol_meross_settings.jinja2
+++ b/src/octoprint_psucontrol_meross/templates/psucontrol_meross_settings.jinja2
@@ -28,6 +28,22 @@
         <fieldset>
             <legend>Meross Cloud</legend>
             <div class="control-group">
+                <label class="control-label" for="settings-psucontrol-meross-url">API URL:</label>
+                <div class="controls">
+                    <select
+                        id="settings-psucontrol-meross-url"
+                        class="input-block-level"
+                        data-bind="
+                            options: settings.api_urls,
+                            optionsText: 'name',
+                            optionsValue: 'url',
+                            selectedOptions settings.api_base_url
+                        "
+                        required=""
+                    ></select>
+                </div>
+            </div>
+            <div class="control-group">
                 <label class="control-label" for="settings-psucontrol-meross-login">Login:</label>
                 <div class="controls">
                     <input type="text" id="settings-psucontrol-meross-login" class="input-block-level" type="text" data-bind="textInput: settings.user_email" required="">

--- a/test/client/test_async_client.py
+++ b/test/client/test_async_client.py
@@ -50,9 +50,9 @@ async def test_client(
 @pytest.mark.asyncio
 async def test_login(test_client, mock_meross_iot_http_client, mock_meross_cache):
     mock_meross_cache.get_cloud_session_token.return_value = None
-    await test_client.login("testuser", "password", raise_exc=True)
+    await test_client.login("api_url", "testuser", "password", raise_exc=True)
     mock_meross_iot_http_client.async_from_user_password.assert_called_once_with(
-        email="testuser", password="password"
+        api_base_url="api_url", email="testuser", password="password"
     )
 
 

--- a/test/test_integration/test_integration_plugin.py
+++ b/test/test_integration/test_integration_plugin.py
@@ -16,7 +16,7 @@ def test_on_settings_initialized(
     threaded_loop.wait_all_futures()
     assert mocked_meross_http_client.async_from_user_password.called
     mocked_meross_http_client.async_from_user_password.assert_called_with(
-        email="settings::user_email::value", password="settings::user_password::value"
+        api_base_url="settings::api_base_url::value", email="settings::user_email::value", password="settings::user_password::value"
     )
     assert (
         mock_shelve_data[

--- a/test/test_integration/test_integration_plugin.py
+++ b/test/test_integration/test_integration_plugin.py
@@ -16,7 +16,9 @@ def test_on_settings_initialized(
     threaded_loop.wait_all_futures()
     assert mocked_meross_http_client.async_from_user_password.called
     mocked_meross_http_client.async_from_user_password.assert_called_with(
-        api_base_url="settings::api_base_url::value", email="settings::user_email::value", password="settings::user_password::value"
+        api_base_url="settings::api_base_url::value",
+        email="settings::user_email::value",
+        password="settings::user_password::value",
     )
     assert (
         mock_shelve_data[


### PR DESCRIPTION
This is a fix for a breaking change from meross-iot where it was introduced the API base URL.

With the changes, there's a new dropdown to let the user select the region where their meross account is registered.

This change is fully tested and I'm using with my setup.