### PR TITLE
Bump meross-iot version to 0.4.6.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.3
+current_version = 0.13.4
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.dev(?P<dev>.*))?

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setuptools.setup(
     entry_points={
         "octoprint.plugin": ["psucontrol_meross = octoprint_psucontrol_meross"]
     },
-    install_requires=["OctoPrint>=1.7.3", "meross-iot>=0.4.6.0"],
+    install_requires=["OctoPrint>=1.7.3", "meross-iot>=0.4.6.2"],
     python_requires=">=3.7.3",
 )


### PR DESCRIPTION
Bumping version of meross-iot dependency to 0.4.6.2